### PR TITLE
k8s: reverse-proxy LLM calls, keep proxy-key server-side

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,8 +1,14 @@
-# LLM config template — API keys injected from k8s secrets at deploy time
+# LLM config template — NO LLM SECRETS.
+#
+# The PROXY_KEY lives only in the nginx config (see `cacao-demo-nginx`
+# below), which injects the Authorization header server-side via
+# `proxy_set_header`. The browser only sees a relative `/api/llm`
+# endpoint and never holds the key.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cacao-demo-config
+  namespace: schmidtdse
 data:
   config.template.json: |
     {
@@ -13,50 +19,52 @@ data:
             {
                 "value": "nemotron",
                 "label": "NRP Nemotron",
-                "endpoint": "${LLM_ENDPOINT}",
-                "api_key": "${PROXY_KEY}"
+                "endpoint": "/api/llm",
+                "api_key": "unused"
             },
             {
                 "value": "glm-4.7",
                 "label": "NRP GLM-4.7",
-                "endpoint": "${LLM_ENDPOINT}",
-                "api_key": "${PROXY_KEY}"
+                "endpoint": "/api/llm",
+                "api_key": "unused"
             },
             {
                 "value": "qwen3",
                 "label": "NRP Qwen3",
-                "endpoint": "${LLM_ENDPOINT}",
-                "api_key": "${PROXY_KEY}"
+                "endpoint": "/api/llm",
+                "api_key": "unused"
             },
             {
                 "value": "gpt-oss",
                 "label": "NRP GPT-OSS 120B",
-                "endpoint": "${LLM_ENDPOINT}",
-                "api_key": "${PROXY_KEY}"
+                "endpoint": "/api/llm",
+                "api_key": "unused"
             },
             {
                 "value": "kimi",
                 "label": "NRP Kimi K2.5",
-                "endpoint": "${LLM_ENDPOINT}",
-                "api_key": "${PROXY_KEY}"
+                "endpoint": "/api/llm",
+                "api_key": "unused"
             },
             {
                 "value": "minimax-m2",
                 "label": "NRP MiniMax M2.5",
-                "endpoint": "${LLM_ENDPOINT}",
-                "api_key": "${PROXY_KEY}"
+                "endpoint": "/api/llm",
+                "api_key": "unused"
             }
         ]
     }
 
 ---
-# Nginx configuration
+# Nginx configuration — reverse-proxies /api/llm/ to open-llm-proxy and
+# injects the Authorization header from ${PROXY_KEY} at container start.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cacao-demo-nginx
+  namespace: schmidtdse
 data:
-  nginx.conf: |
+  nginx.conf.template: |
     server {
         listen 80;
         server_name _;
@@ -67,6 +75,17 @@ data:
         add_header Access-Control-Allow-Origin *;
         add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
         add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Accept";
+
+        location /api/llm/ {
+            proxy_pass https://open-llm-proxy.nrp-nautilus.io/v1/;
+            proxy_set_header Authorization "Bearer ${PROXY_KEY}";
+            proxy_set_header Host open-llm-proxy.nrp-nautilus.io;
+            proxy_ssl_server_name on;
+
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_buffering off;
+        }
 
         location / {
             try_files $uri $uri/ /index.html;

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -46,8 +46,6 @@ spec:
           value: "/tmp"
         - name: MCP_SERVER_URL
           value: "https://duckdb-mcp.nrp-nautilus.io/mcp"
-        - name: LLM_ENDPOINT
-          value: "https://open-llm-proxy.nrp-nautilus.io/v1"
         - name: PROXY_KEY
           valueFrom:
             secretKeyRef:
@@ -58,7 +56,16 @@ spec:
         - -c
         - |
           apk add --no-cache gettext
-          envsubst < /config/config.template.json > /usr/share/nginx/html/config.json
+          # Client-side config: no LLM secrets.
+          envsubst '$${MCP_SERVER_URL}' \
+            < /config/config.template.json \
+            > /usr/share/nginx/html/config.json
+          # Server-side nginx config: substitutes ${PROXY_KEY} into the
+          # /api/llm/ reverse proxy's Authorization header. Limited to
+          # ${PROXY_KEY} so nginx's own $uri / $remote_addr variables
+          # are preserved.
+          envsubst '$${PROXY_KEY}' < /nginx-template/nginx.conf.template \
+            > /etc/nginx/conf.d/default.conf
           nginx -g 'daemon off;'
         resources:
           requests:
@@ -70,9 +77,11 @@ spec:
         volumeMounts:
         - name: website-content
           mountPath: /usr/share/nginx/html
-        - name: nginx-config
-          mountPath: /etc/nginx/conf.d/default.conf
-          subPath: nginx.conf
+        - name: nginx-template
+          mountPath: /nginx-template
+          readOnly: true
+        - name: nginx-conf-d
+          mountPath: /etc/nginx/conf.d
         - name: config-template
           mountPath: /config
         livenessProbe:
@@ -93,6 +102,8 @@ spec:
       - name: config-template
         configMap:
           name: cacao-demo-config
-      - name: nginx-config
+      - name: nginx-template
         configMap:
           name: cacao-demo-nginx
+      - name: nginx-conf-d
+        emptyDir: {}


### PR DESCRIPTION
altering the proxy config on k8s to match other apps; should have no user-facing changes