### PR TITLE
bump geo-agent pin to @v3.6.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/sql.min.js"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.3.0/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.3.0/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.3.0/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/sidebar.css">
 </head>
 
 <body>
@@ -52,7 +52,7 @@
     <div id="menu"></div>
 
     <!-- Boot from CDN -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.3.0/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.6.0/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Bumps the geo-agent CDN pin in `index.html` from `@v3.3.0` to `@v3.6.0`.

See [v3.6.0 release notes](https://github.com/boettiger-lab/geo-agent/releases/tag/v3.6.0) — adds client-side `add_hex_tile_layer` consumer for the MCP server's `register_hex_tiles` payload. No JS API breaks.

Coordinated rollout across all deployed apps to prepare for `register_hex_tiles` being enabled on the production MCP server.