### PR TITLE
fix: update WDPA collection_url for protected-planet move

### DIFF
--- a/layers-input.json
+++ b/layers-input.json
@@ -67,7 +67,7 @@
         },
         {
             "collection_id": "wdpa-december-2025",
-            "collection_url": "https://s3-west.nrp-nautilus.io/public-wdpa/stac-collection.json",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-wdpa/wdpa-december-2025/stac-collection.json",
             "assets": [
                 {
                     "id": "wdpa-pmtiles",


### PR DESCRIPTION
Fix WDPA collection resolution after upstream bucket restructure.

The `public-wdpa` bucket was reorganized so that data now lives under `wdpa-december-2025/` and `public-wdpa/stac-collection.json` is now a `protected-planet` parent collection with `wdpa-december-2025` and `wdoecm-may-2026` as children. Geo-agent's `DatasetCatalog.load()` does only a 1-level catalog walk and doesn't recurse through intermediate Collection nodes (per [geo-agent#178](https://github.com/boettiger-lab/geo-agent/issues/178), closed won't-fix) — so without an explicit `collection_url` pointing to the leaf, the WDPA layer drops out.

This PR sets `collection_url` to the new leaf collection URL.

Tracked in [boettiger-lab/geo-agent-ops#14](https://github.com/boettiger-lab/geo-agent-ops/issues/14).