### PR TITLE
Data migrations: canonical collection_url + WDPA/ghs-pop repoint

### DIFF
--- a/layers-input.json
+++ b/layers-input.json
@@ -66,8 +66,8 @@
             ]
         },
         {
-            "collection_id": "wdpa-december-2025",
-            "collection_url": "https://s3-west.nrp-nautilus.io/public-wdpa/wdpa-december-2025/stac-collection.json",
+            "collection_id": "wdpa",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-wdpa/wdpa/stac-collection.json",
             "assets": [
                 {
                     "id": "wdpa-pmtiles",
@@ -92,6 +92,7 @@
         },
         {
             "collection_id": "irrecoverable-carbon",
+            "collection_url": "https://s3-west.nrp-nautilus.io/public-carbon/stac-collection.json",
             "assets": [
                 {
                     "id": "v2-vulnerable-2024-cog",


### PR DESCRIPTION
Data-catalog migrations (tracking boettiger-lab/geo-agent-ops#14, #15, #16):

- #16 WDPA `collection_id`/`collection_url` → date-independent `wdpa`
- #14 add `collection_url` to `irrecoverable-carbon`

All target collection ids/urls verified against live STAC (ids match, referenced assets present).