### PR TITLE
k8s: pin namespace (schmidtdse) in manifests

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,6 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  namespace: schmidtdse
   name: cacao-demo-ingress
   annotations:
     haproxy-ingress.github.io/cors-enable: "true"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: schmidtdse
   name: cacao-demo
   labels:
     app: cacao-demo


### PR DESCRIPTION
Manifest hygiene tracked in geo-agent-ops.

- **Pin namespace** (schmidtdse) in each manifest's `metadata:` so `kubectl apply -f k8s/` targets the right namespace without `-n` (kills the guess-the-namespace step on every rollout; APPS.md TODO).

No behavioral change — apps already run in this namespace.