### PR TITLE
Bump geo-agent pin @v3.13.1 → @v3.15.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
         crossorigin="anonymous"></script>
 
     <!-- Core styles from CDN -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.13.1/app/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.13.1/app/chat.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.13.1/app/sidebar.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.15.0/app/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.15.0/app/chat.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.15.0/app/sidebar.css">
 </head>
 
 <body>
@@ -73,7 +73,7 @@
     <div id="menu"></div>
 
     <!-- Boot from CDN -->
-    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.13.1/app/main.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/boettiger-lab/geo-agent@v3.15.0/app/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Pure CDN pin bump (4 refs). `app/index.html` byte-unchanged across v3.13.1..v3.15.0; no SRI/DOMPurify/config work. Both releases declare no breaking changes.